### PR TITLE
Update image to modern needs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,11 @@ RUN apt-get update \
     python3.4 \
     python3.4-dev \
     python3-pip \
-    busybox \
     && apt-get autoremove \
     && apt-get clean
     
-WORKDIR /tmp
-RUN busybox wget http://cdn.rawgit.com/pypa/pip/b9f2d5d5bb4c9dba8dbba3cc09a24fefb12fb38e/contrib/get-pip.py && python3 get-pip.py && rm get-pip.py
+ADD https://bootstrap.pypa.io/get-pip.py /tmp
+RUN python3 /tmp/get-pip.py && rm /tmp/get-pip.py
 
 RUN pip3 install -U "virtualenv==12.0.7"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
 ADD https://bootstrap.pypa.io/get-pip.py /tmp/
 RUN python3 /tmp/get-pip.py && rm /tmp/get-pip.py
 
-RUN pip3 install -U "virtualenv==12.0.7"
+RUN pip3 install -U "virtualenv==12.1.1"
 
 CMD []
 ENTRYPOINT ["/usr/bin/python3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 # Base python 3.4 build, inspired by
 # https://github.com/crosbymichael/python-docker/blob/master/Dockerfile
 FROM ubuntu:14.04
-MAINTAINER Michael Twomey, mick@twomeylee.name
-
-RUN echo "deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main" > /etc/apt/sources.list.d/deadsnakes.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DB82666C
+MAINTAINER Michael Twomey <mick@twomeylee.name>
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -19,15 +16,14 @@ RUN apt-get update \
     pkg-config \
     python3.4 \
     python3.4-dev \
+    python3-pip \
     ssh \
     && apt-get autoremove \
     && apt-get clean
 
-ADD https://github.com/pypa/pip/raw/645180e2714b4ffcf40363a608239e089c9dafab/contrib/get-pip.py /root/get-pip.py
-RUN python3.4 /root/get-pip.py
-RUN pip3.4 install -U "setuptools==3.5.1"
-RUN pip3.4 install -U "pip==1.5.5"
-RUN pip3.4 install -U "virtualenv==1.11.5"
+RUN pip3.4 install -U "setuptools==14.3.1"
+RUN pip3.4 install -U "pip==6.0.8"
+RUN pip3.4 install -U "virtualenv==12.0.7"
 
 CMD []
-ENTRYPOINT ["/usr/bin/python3.4"]
+ENTRYPOINT ["/usr/bin/python3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && apt-get autoremove \
     && apt-get clean
     
-ADD https://bootstrap.pypa.io/get-pip.py /tmp
+ADD https://bootstrap.pypa.io/get-pip.py /tmp/
 RUN python3 /tmp/get-pip.py && rm /tmp/get-pip.py
 
 RUN pip3 install -U "virtualenv==12.0.7"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,16 @@ RUN apt-get update \
     python3.4-dev \
     python3-pip \
     ssh \
+    busybox \
     && apt-get autoremove \
     && apt-get clean
+    
+WORKDIR /tmp
+RUN busybox wget http://cdn.rawgit.com/pypa/pip/b9f2d5d5bb4c9dba8dbba3cc09a24fefb12fb38e/contrib/get-pip.py && python3 get-pip.py && rm get-pip.py
 
-RUN pip3.4 install -U "setuptools==14.3.1"
-RUN pip3.4 install -U "pip==6.0.8"
-RUN pip3.4 install -U "virtualenv==12.0.7"
+RUN pip3 install -U "setuptools==14.3.1"
+RUN pip3 install -U "pip==6.0.8"
+RUN pip3 install -U "virtualenv==12.0.7"
 
 CMD []
 ENTRYPOINT ["/usr/bin/python3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,10 @@ RUN apt-get update \
     git \
     libpq-dev \
     make \
-    mercurial \
     pkg-config \
     python3.4 \
     python3.4-dev \
     python3-pip \
-    ssh \
     busybox \
     && apt-get autoremove \
     && apt-get clean
@@ -25,8 +23,6 @@ RUN apt-get update \
 WORKDIR /tmp
 RUN busybox wget http://cdn.rawgit.com/pypa/pip/b9f2d5d5bb4c9dba8dbba3cc09a24fefb12fb38e/contrib/get-pip.py && python3 get-pip.py && rm get-pip.py
 
-RUN pip3 install -U "setuptools==14.3.1"
-RUN pip3 install -U "pip==6.0.8"
 RUN pip3 install -U "virtualenv==12.0.7"
 
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update \
     pkg-config \
     python3.4 \
     python3.4-dev \
-    python3-pip \
     && apt-get autoremove \
     && apt-get clean
     


### PR DESCRIPTION
This image is a year old (!). It is in need of update to modern specifications. Therefore, this pull request changes some things:
- The maintainer format is changed to the standard syntax
- This image no longer uses the deadsnakes repository, as the version of python 3.4 in the default repositories is guaranteed to be secure (as much as possible), and is modern enough
- ssh is no longer installed, as you can get into a container without ssh in the latest version of Docker, and the user can install it if they want
- mercurial is no longer installed, as it is much less popular than git, and can be installed using pip if necessary
- pip is installed through the official get-pip.py download, and the file is removed afterwards
- pip and setuptools are no longer updated, as they should be fully up to date from the pip installation
- virtualenv is updated however, since it is not installed by default
- references to python3.4 and pip3.4 are replaced with python3 and pip3
